### PR TITLE
Fix protobuf dependency conflicts

### DIFF
--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,6 +1,6 @@
 tinkoff-investments==0.2.0b115
 python-dotenv==0.21.0
-protobuf==3.20.2
+protobuf>=4.25.1,<5.0.0
 aiogram==2.22.1
 aiohttp==3.8.2
 yarl==1.8.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,8 +9,7 @@ pytest-mock==3.10.0
 factory-boy==3.2.1
 django==2.2.19
 djangorestframework==3.12.4
-pytest-django==4.5.2
 tinkoff-investments==0.2.0b115
 python-dotenv==0.21.0
-protobuf==3.20.2
+protobuf>=4.25.1,<5.0.0
 aiogram==2.22.1

--- a/trademan/requirements.txt
+++ b/trademan/requirements.txt
@@ -1,6 +1,6 @@
 django==2.2.19
 tinkoff-investments==0.2.0b115
 python-dotenv==0.21.0
-protobuf==3.20.2
+protobuf>=4.25.1,<5.0.0
 djangorestframework==3.12.4
 pytest-django==4.5.2


### PR DESCRIPTION
## Summary
- bump protobuf version requirement to match tinkoff-investments
- clean up duplicate requirement in tests

## Testing
- `pip install -r requirements-tests.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e67d6be748328bbfa4912e7f75946