### PR TITLE
Fix backend container distutils issue

### DIFF
--- a/trademan/Dockerfile
+++ b/trademan/Dockerfile
@@ -3,5 +3,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /base
 # RUN apt-get update && apt-get -y install gcc
 COPY . .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir setuptools && \
+    pip install --no-cache-dir -r requirements.txt
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- ensure distutils is present when building backend container by installing setuptools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688507205854832882bd261d10b2ce40